### PR TITLE
Comment out newRoute installation in main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func main() {
 		//new web controller
 		exampleController,
 	)
-	newRoute.Install(app)
+	// newRoute.Install(app)
 
 	log.Fatal(app.Listen(fmt.Sprintf(":%s", config.Env("app.port"))))
 }


### PR DESCRIPTION
🤖 **AI Code Review**

## Summary
This change comments out the line that installs newRoute onto the app web server, preventing newRoute from being added to the application's routing.

## ✅ Strengths
- The change is simple and clearly indicates that newRoute is being disabled, possibly for debugging or testing purposes.
- Does not introduce any breaking syntax errors.

## ⚠️ Issues / Improvements
_None_

## 🔎 Merge Checklist
- [ ] ✅ Application still builds and runs without error
- [ ] ✅ All tests related to routes pass or are properly skipped/updated
- [ ] ✅ Documentation or comments updated to reflect route change
- [ ] ✅ Confirm that removing newRoute is temporary or intentional
